### PR TITLE
Add support for custom datetime fields

### DIFF
--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -57,9 +57,9 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                     case "collection":
                         t = DataType.Collection(DataType.String);
                         break;
-	                case "datetime":
-		                t = DataType.DateTimeOffset;
-		                break;
+                    case "datetime":
+                        t = DataType.DateTimeOffset;
+                        break;
 				}
 
                 var f = new Field()
@@ -465,8 +465,8 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                     if (field.Type == "bool")
                         c.Add(field.Name, false);
 
-	                if (field.Type == "datetime")
-		                c.Add(field.Name, null);
+                    if (field.Type == "datetime")
+                        c.Add(field.Name, null);
 				}
                 else
                 {

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -57,7 +57,10 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                     case "collection":
                         t = DataType.Collection(DataType.String);
                         break;
-                }
+	                case "datetime":
+		                t = DataType.DateTimeOffset;
+		                break;
+				}
 
                 var f = new Field()
                 {
@@ -462,7 +465,9 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                     if (field.Type == "bool")
                         c.Add(field.Name, false);
 
-                }
+	                if (field.Type == "datetime")
+		                c.Add(field.Name, null);
+				}
                 else
                 {
                     var value = content.Properties[field.Name].Value;

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -60,7 +60,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                     case "datetime":
                         t = DataType.DateTimeOffset;
                         break;
-				}
+                }
 
                 var f = new Field()
                 {
@@ -467,7 +467,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
 
                     if (field.Type == "datetime")
                         c.Add(field.Name, null);
-				}
+                }
                 else
                 {
                     var value = content.Properties[field.Name].Value;


### PR DESCRIPTION
The AzureSearchIndexClient will currently index any custom datetime fields defined in AzureSearch.config as a string which causes date range searches on these dates to fall over.

This change makes sure that 'datetime' search fields are indexed with the DateTimeOffset data type, similar to  what has already been done with standard Umbraco fields such as 'UpdateDate' or 'CreateDate'.