### PR TITLE
Wrap document conversion calls in try/catch

### DIFF
--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -304,7 +304,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
 
             if (conversionErrors)
             {
-                result.Message += $"Failed to create azure search documents from some umbraco documents: {string.Join(", ", failedDocumentConversionIds)}\n";
+                result.Message += $"Failed to convert Umbraco content to Azure search documents: {string.Join(", ", failedDocumentConversionIds)}\n";
             }
 
             var indexStatus = IndexContentBatch(documents);

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
 using Moriyama.AzureSearch.Umbraco.Application.Interfaces;
@@ -216,11 +217,14 @@ namespace Moriyama.AzureSearch.Umbraco.Application
         public AzureSearchReindexStatus ReIndex(string filename, string sessionId, int page)
         {
             var ids = GetIds(sessionId, filename);
+            var conversionErrors = false;
+            var failedDocumentConversionIds = new List<int>();
 
             var result = new AzureSearchReindexStatus
             {
                 SessionId = sessionId,
-                DocumentCount = ids.Length
+                DocumentCount = ids.Length,
+                Message = string.Empty
             };
 
             var idsToProcess = Page(ids, page);
@@ -239,16 +243,40 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             {
                 var contents = UmbracoContext.Current.Application.Services.ContentService.GetByIds(idsToProcess);
                 foreach (var content in contents)
+                {
                     if (content != null)
-                        documents.Add(FromUmbracoContent(content, config.SearchFields));
+                    {
+                        try
+                        {
+                            documents.Add(FromUmbracoContent(content, config.SearchFields));
+                        }
+                        catch (Exception ex)
+                        {
+                            conversionErrors = true;
+                            failedDocumentConversionIds.Add(content.Id);
+                        }
+                    }
+                }
             }
             else if (filename == "media.json")
             {
                 var contents = UmbracoContext.Current.Application.Services.MediaService.GetByIds(idsToProcess);
 
                 foreach (var content in contents)
+                {
                     if (content != null)
-                        documents.Add(FromUmbracoMedia(content, config.SearchFields));
+                    {
+                        try
+                        {
+                            documents.Add(FromUmbracoMedia(content, config.SearchFields));
+                        }
+                        catch (Exception ex)
+                        {
+                            conversionErrors = true;
+                            failedDocumentConversionIds.Add(content.Id);
+                        }
+                    }
+                }
             }
             else
             {
@@ -258,12 +286,29 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                     contents.Add(UmbracoContext.Current.Application.Services.MemberService.GetById(id));
 
                 foreach (var content in contents)
+                {
                     if (content != null)
-                        documents.Add(FromUmbracoMember(content, config.SearchFields));
+                    {
+                        try
+                        {
+                            documents.Add(FromUmbracoMember(content, config.SearchFields));
+                        }
+                        catch (Exception ex)
+                        {
+                            conversionErrors = true;
+                            failedDocumentConversionIds.Add(content.Id);
+                        }
+                    }
+                }
+            }
+
+            if (conversionErrors)
+            {
+                result.Message += $"Failed to create azure search documents from some umbraco documents: {string.Join(", ", failedDocumentConversionIds)}\n";
             }
 
             var indexStatus = IndexContentBatch(documents);
-
+            
             result.DocumentsProcessed = page * BatchSize;
 
             if (indexStatus.Success)
@@ -273,7 +318,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
 
             result.Error = true;
             result.Finished = true;
-            result.Message = indexStatus.Message;
+            result.Message += indexStatus.Message;
 
             return result;
         }


### PR DESCRIPTION
Currently if some Umbraco content can not be converted to an Azure document the indexing will fail and stop indexing any more items. This scenario typically happens because the Umbraco content has somehow become invalid.

This change catches theses documents conversion errors and gives the IDs of any content that failed to be converted in the error message, rather than stopping the whole indexing process.