### PR TITLE
Feature/indexupdates

### DIFF
--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
@@ -65,7 +65,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             return this;
         }
 
-        private SearchParameters GetSearchParameters()
+        public SearchParameters GetSearchParameters()
         {
             var sp = new SearchParameters();
 
@@ -101,7 +101,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             return Results(sp);
         }
 
-        private ISearchResult Results(SearchParameters sp)
+        public ISearchResult Results(SearchParameters sp)
         {
             var client = GetClient();
             var config = GetConfiguration();

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
@@ -279,6 +279,12 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             return this;
         }
 
+        public IAzureSearchClient Filter(string filter)
+        {
+            _filters.Add(filter);
+            return this;
+        }
+
         public IAzureSearchClient Facet(string facet)
         {
             _facets.Add(facet);
@@ -292,6 +298,12 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                 _facets.Add(facet);
             }
 
+            return this;
+        }
+
+        public IAzureSearchClient SearchIn(string field, IEnumerable<string> values)
+        {
+            _filters.Add($"search.in({field}, '{string.Join(",", values)}')");
             return this;
         }
 

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
@@ -29,6 +29,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
         private string _searchTerm = "*";
         private IList<string> _orderBy;
         private IList<string> _facets;
+        private QueryType _queryType = QueryType.Simple;
 
         private bool _content;
         private bool _media;
@@ -89,6 +90,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             sp.Skip = (_page - 1) * _pageSize;
             sp.OrderBy = _orderBy;
             sp.Facets = _facets;
+            sp.QueryType = _queryType;
 
             return sp;
         }
@@ -420,6 +422,11 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             };
 
             return indexClient.Documents.Suggest(value, "sg", sp).Results;
+        }
+
+        public void SetQueryType(QueryType type)
+        {
+            _queryType = type;
         }
     }
 }

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -371,6 +371,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                 {"Name", content.Name},
                 {"SortOrder", content.SortOrder},
                 {"Level", content.Level},
+                {"SearchablePath", content.Path.TrimStart('-') },
                 {"Path", content.Path.Split(',') },
                 {"ParentId", content.ParentId},
                 {"UpdateDate", content.UpdateDate},
@@ -523,6 +524,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                  new Field("Published", DataType.Boolean) { IsFilterable = true, IsFacetable = true },
                  new Field("Trashed", DataType.Boolean) { IsFilterable = true, IsFacetable = true },
 
+                 new Field("SearchablePath", DataType.String) { IsSearchable = true, IsFilterable = true},
                  new Field("Path", DataType.Collection(DataType.String)) { IsSearchable = true, IsFilterable = true },
                  new Field("Template", DataType.String) { IsSearchable = true, IsFacetable = true },
                  new Field("Icon", DataType.String) { IsSearchable = true, IsFacetable = true },

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -506,10 +506,10 @@ namespace Moriyama.AzureSearch.Umbraco.Application
         public Field[] GetStandardUmbracoFields()
         {
             // Key field has to be a string....
-            return new[]
-            {
-                 new Field("Id", DataType.String) { IsKey = true, IsFilterable = true, IsSortable = true },
+            var key = new Field("Id", DataType.String) { IsKey = true, IsFilterable = true, IsSortable = true };
 
+            var fields = new []
+            {
                  new Field("Name", DataType.String) { IsFilterable = true, IsSortable = true, IsSearchable = true, IsRetrievable = true},
                  new Field("Key", DataType.String) { IsSearchable = true, IsRetrievable = true},
 
@@ -540,6 +540,11 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                  new Field("WriterId", DataType.Int32) { IsSortable = true, IsFacetable = true },
                  new Field("CreatorId", DataType.Int32) { IsSortable = true, IsFacetable = true }
             };
+
+            var sorted = new List<Field>(fields.OrderBy(f => f.Name));
+            sorted.Insert(0, key);
+
+            return sorted.ToArray();
         }
     }
 }

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -35,6 +35,8 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             return Path.Combine(path, sessionId + ".json");
         }
 
+        public event EventHandler<Index> CreatingIndex;
+
         public string DropCreateIndex()
         {
             var serviceClient = GetClient();
@@ -56,6 +58,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
 
             try
             {
+                CreatingIndex?.Invoke(this, definition);
                 serviceClient.Indexes.Create(definition);
             }
             catch (Exception ex)

--- a/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
@@ -43,5 +43,6 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         IAzureSearchClient SearchIn(string field, IEnumerable<string> values);
 
         IList<SuggestResult> Suggest(string value, int count, bool fuzzy = true);
+        void SetQueryType(QueryType type);
     }
 }

--- a/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
@@ -26,6 +26,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         IAzureSearchClient Filter(string field, string[] values);
         IAzureSearchClient Filter(string field, int value);
         IAzureSearchClient Filter(string field, bool value);
+        IAzureSearchClient Filter(string filter);
 
         IAzureSearchClient DateRange(string field, DateTime? start, DateTime? end);
 
@@ -38,6 +39,8 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         IAzureSearchClient Contains(IEnumerable<string> fields, IEnumerable<string> values);
 
         IAzureSearchClient Any(string field);
+
+        IAzureSearchClient SearchIn(string field, IEnumerable<string> values);
 
         IList<SuggestResult> Suggest(string value, int count, bool fuzzy = true);
     }

--- a/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
@@ -9,6 +9,8 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         IList<string> Filters { get; set; }
 
         ISearchResult Results();
+        ISearchResult Results(SearchParameters sp);
+        SearchParameters GetSearchParameters();
 
         IAzureSearchClient Term(string query);
         IAzureSearchClient DocumentType(string typeAlias);

--- a/Moriyama.AzureSearch.Umbraco.Application/Interfaces/ISearchContent.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Interfaces/ISearchContent.cs
@@ -22,6 +22,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         int Level { get; set; }
 
         string[] Path { get; set; }
+        string SearchablePath { get; set; }
 
         int ParentId { get; set; }
 

--- a/Moriyama.AzureSearch.Umbraco.Application/Models/SearchContent.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Models/SearchContent.cs
@@ -18,6 +18,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Models
         public bool IsMember { get; set; }
 
         public string[] Path { get; set; }
+        public string SearchablePath { get; set; }
 
         public IDictionary<string, object> Properties { get; set; }
     }


### PR DESCRIPTION
Various updates for azure indexes

Add event for CreatingIndex to allow custom modification to the index
Sorted umbraco fields alphabetically, keeping key/id at the top
Add search term highlighting to assist with identifying why an item was matched
Add searchablepath to allow searching for path.startswith etc
Add search.in and filter support - see [search.in](https://docs.microsoft.com/en-us/rest/api/searchservice/odata-expression-syntax-for-azure-search)
Add support for full query syntax - see [Lucene syntax](https://docs.microsoft.com/en-us/rest/api/searchservice/lucene-query-syntax-in-azure-search)
Add support for custom search params