### PR TITLE
Reposition Where Content_Indexed Event is triggered

### DIFF
--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchServiceClient.cs
@@ -300,7 +300,13 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             }
 
             result.Add("Icon", member.ContentType.Icon);
-
+            //finished populating index items
+            AzureSearch.FireContentIndexed(
+            new AzureSearchEventArgs()
+            {
+                Item = member,
+                Entry = result
+            });
             return result;
         }
 
@@ -321,7 +327,13 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             result.Add("IsMember", false);
             result.Add("ContentTypeAlias", content.ContentType.Alias);
             result.Add("Icon", content.ContentType.Icon);
-
+            //finished populating index items
+            AzureSearch.FireContentIndexed(
+            new AzureSearchEventArgs()
+            {
+                Item = content,
+                Entry = result
+            });
             return result;
         }
 
@@ -356,7 +368,13 @@ namespace Moriyama.AzureSearch.Umbraco.Application
                 result.Add("Template", content.Template.Alias);
 
             result.Add("Icon", content.ContentType.Icon);
-
+            //finished populating index items
+            AzureSearch.FireContentIndexed(
+            new AzureSearchEventArgs()
+            {
+                Item = content,
+                Entry = result
+            });
             return result;
         }
 
@@ -393,13 +411,6 @@ namespace Moriyama.AzureSearch.Umbraco.Application
 
             c = FromUmbracoContentBase(c, content, umbracoFields);
             c = FromComputedFields(c, content, computedFields);
-
-            AzureSearch.FireContentIndexed(
-                new AzureSearchEventArgs()
-                {
-                    Item = content,
-                    Entry = c
-                });
 
             return c;
         }


### PR DESCRIPTION
Previously the Content_Indexed Event was triggered, after all of the custom properties were added to the dictionary of items to add to the Azure Search Index, but before certain 'system' properties such as 'Published', 'Url', 'IsContent' etc, this commit repositions this even to fire after these 'system' properties have been set to enable applications to change the values of these items during indexing, for example when using 'Archived' Content with Azure Search, the Published and Url settings would need to be overridden in the Indexed Event.