### PR TITLE
Update IAzureSearchClient to add scoring profile overload

### DIFF
--- a/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
@@ -9,7 +9,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         IList<string> Filters { get; set; }
 
         ISearchResult Results();
-
+        ISearchResult Results(string scoringProfile);
         IAzureSearchClient Term(string query);
         IAzureSearchClient DocumentType(string typeAlias);
         IAzureSearchClient DocumentTypes(IEnumerable<string> typeAlias);


### PR DESCRIPTION
AzureSearchClient has an overload for a scoring profile ... Results(scoringProfileName) but it isn't on the interface, this PR just adds the signature to the interface, which makes it easier to call when building a query, without casting to the concrete object.