### PR TITLE
Feature/exclude doctypes

### DIFF
--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
@@ -71,6 +71,24 @@ namespace Moriyama.AzureSearch.Umbraco.Application
             return this;
         }
 
+        public IAzureSearchClient ExcludeDocumentType(string typeAlias)
+        {
+            _filters.Add(string.Format("ContentTypeAlias ne '{0}'", typeAlias));
+            return this;
+        }
+
+        public IAzureSearchClient ExcludeDocumentTypes(IEnumerable<string> typeAliases)
+        {
+            var combinedFilter = string.Format("({0})",
+                string.Join(" or ",
+                    typeAliases.Select(x =>
+                        string.Format("ContentTypeAlias ne '{0}'", x)).ToList())
+            );
+
+            _filters.Add(combinedFilter);
+            return this;
+        }
+
         private SearchParameters GetSearchParameters(string scoringProfile = null)
         {
             var sp = new SearchParameters()

--- a/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/AzureSearchClient.cs
@@ -80,7 +80,7 @@ namespace Moriyama.AzureSearch.Umbraco.Application
         public IAzureSearchClient ExcludeDocumentTypes(IEnumerable<string> typeAliases)
         {
             var combinedFilter = string.Format("({0})",
-                string.Join(" or ",
+                string.Join(" and ",
                     typeAliases.Select(x =>
                         string.Format("ContentTypeAlias ne '{0}'", x)).ToList())
             );

--- a/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
+++ b/Moriyama.AzureSearch.Umbraco.Application/Interfaces/IAzureSearchClient.cs
@@ -13,6 +13,8 @@ namespace Moriyama.AzureSearch.Umbraco.Application.Interfaces
         IAzureSearchClient Term(string query);
         IAzureSearchClient DocumentType(string typeAlias);
         IAzureSearchClient DocumentTypes(IEnumerable<string> typeAlias);
+        IAzureSearchClient ExcludeDocumentType(string typeAlias);
+        IAzureSearchClient ExcludeDocumentTypes(IEnumerable<string> typeAlias);
         IAzureSearchClient OrderBy(string fieldName);
 
         IAzureSearchClient Content();


### PR DESCRIPTION
Added 2 new methods for excluding Document Types. Tested using the sandbox application pointing to our indexs.